### PR TITLE
fix: USH→UH park code bug in entity_wti_diagnostics + begin park_code centralization

### DIFF
--- a/scripts/entity_wti_diagnostics.py
+++ b/scripts/entity_wti_diagnostics.py
@@ -26,6 +26,8 @@ from zoneinfo import ZoneInfo
 if str(Path(__file__).parent.parent / "src") not in sys.path:
     sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from utils.park_code import entity_code_to_park_code
+
 import duckdb
 import pandas as pd
 
@@ -45,14 +47,6 @@ PARK_NAMES = {
     "UF": "Universal Florida",
     "UH": "Universal Hollywood",
 }
-
-
-def entity_code_to_park(code: str) -> str:
-    """Extract park code from entity code (e.g., MK01 -> MK, TDS12 -> TDS)."""
-    for prefix in ["TDL", "TDS"]:
-        if code.startswith(prefix):
-            return prefix
-    return ''.join(c for c in code if c.isalpha())
 
 
 def get_entity_names(pipeline_dir: Path) -> dict:
@@ -143,7 +137,7 @@ def get_entity_diagnostics(eval_date: str, pipeline_dir: Path, park_filter: str 
     
     # 4. Merge forecasts with actuals
     merged = forecasts.merge(actuals, on="entity_code", how="inner")
-    merged["park"] = merged["entity_code"].apply(entity_code_to_park)
+    merged["park"] = merged["entity_code"].apply(entity_code_to_park_code)
     merged["error"] = merged["forecast_avg"] - merged["actual_avg"]
     merged["abs_error"] = merged["error"].abs()
     


### PR DESCRIPTION
## What

Fix a **live bug** in `entity_wti_diagnostics.py` and begin centralizing park_code mappings per #pipeline item 3.

## The Bug

`entity_wti_diagnostics.py` had its own inline `entity_code_to_park()` function that **stripped all digits and returned the full alpha prefix**:

```python
def entity_code_to_park(code: str) -> str:
    for prefix in ["TDL", "TDS"]:
        if code.startswith(prefix):
            return prefix
    return ''.join(c for c in code if c.isalpha())
```

This means:
- `USH01` → `"USH"` ❌ (should be `"UH"`)
- `MK01` → `"MK"` ✅ (works by accident)
- `TDL01` → `"TDL"` ✅ (hardcoded special case)

Universal Hollywood entities were being grouped under a nonexistent `"USH"` park code in diagnostics, making UH accuracy invisible in entity-level WTI reports.

## The Fix

Replaced the buggy inline function with the canonical `entity_code_to_park_code()` from `src/utils/park_code.py` — the same module that `forecast_vectorized.py` already uses correctly.

## Still TODO (follow-up commits)

Two more scripts have **duplicate but correct** inline `park_code_sql()` functions that should also be migrated to the canonical import:

1. `scripts/calculate_wti_simple.py` — inline `park_code_sql()` (identical to canonical)
2. `scripts/wti_entity_breakdown.py` — inline `park_code_sql()` (identical to canonical)

These aren't bugs today, but they're the exact pattern that *created* this bug — someone copies the function, modifies it slightly, and it drifts.

## Risk

Low. The canonical `entity_code_to_park_code()` is already production-proven in `forecast_vectorized.py`. The diagnostics script is a reporting tool, not in the critical pipeline path.

🪨 Barney — putting Bam-Bam to work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps a local parsing helper for the shared `entity_code_to_park_code()` mapping in a reporting script, primarily affecting park grouping/filters (not core pipeline processing).
> 
> **Overview**
> Fixes park grouping in `entity_wti_diagnostics.py` by removing its bespoke `entity_code_to_park()` logic and instead using the canonical `utils.park_code.entity_code_to_park_code()` mapping (notably correcting `USH*` entities to `UH`).
> 
> This ensures per-park diagnostics, filtering, and aggregation use the same park-code derivation as the rest of the codebase.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 455e90b0b2b91dd4df8a063468bb2232b84c175d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->