### PR TITLE
[ops#27] Remove hardcoded BRAVE_API_KEY literals + strengthen secret scanner

### DIFF
--- a/data/school_schedules/archive/scripts/improved_scraper_test.py
+++ b/data/school_schedules/archive/scripts/improved_scraper_test.py
@@ -16,7 +16,7 @@ import time
 import requests
 from datetime import datetime
 
-BRAVE_API_KEY = os.environ.get("BRAVE_SEARCH_API_KEY", "BSAEB_N4ZkM3WOQN6bokdPKGkL6HWuN")
+BRAVE_API_KEY = os.environ.get("BRAVE_SEARCH_API_KEY")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 FIRECRAWL_API_KEY = os.environ.get("FIRECRAWL_API_KEY", "")
 

--- a/data/school_schedules/archive/scripts/mass_scraper.py
+++ b/data/school_schedules/archive/scripts/mass_scraper.py
@@ -35,7 +35,7 @@ NCES_ALL_FILE = BASE_DIR / "nces_all_districts.csv"
 RESULTS_FILE = BASE_DIR / "mass_scraper_results.json"
 LOG_FILE = BASE_DIR / "mass_scraper.log"
 
-BRAVE_API_KEY = "BSAEB_N4ZkM3WOQN6bokdPKGkL6HWuN"
+BRAVE_API_KEY = ""
 BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
 FIRECRAWL_API_KEY = os.environ.get("FIRECRAWL_API_KEY", "")
 FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v1/scrape"

--- a/data/school_schedules/archive/scripts/mass_scraper_v2.py
+++ b/data/school_schedules/archive/scripts/mass_scraper_v2.py
@@ -35,7 +35,7 @@ NCES_ALL_FILE = BASE_DIR / "nces_all_districts.csv"
 RESULTS_FILE = BASE_DIR / "mass_scraper_v2_results.json"
 LOG_FILE = BASE_DIR / "mass_scraper_v2.log"
 
-BRAVE_API_KEY = "BSAEB_N4ZkM3WOQN6bokdPKGkL6HWuN"
+BRAVE_API_KEY = ""
 BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
 FIRECRAWL_API_KEY = os.environ.get("FIRECRAWL_API_KEY", "")
 FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v1/scrape"

--- a/data/school_schedules/archive/scripts/mega_scraper.py
+++ b/data/school_schedules/archive/scripts/mega_scraper.py
@@ -32,7 +32,7 @@ CONFIRMATION_RESULTS = BASE_DIR / "confirmation_results.json"
 MEGA_RESULTS_FILE = BASE_DIR / "mega_scraper_results.json"
 LOG_FILE = BASE_DIR / "mega_scraper.log"
 
-BRAVE_API_KEY = "BSAEB_N4ZkM3WOQN6bokdPKGkL6HWuN"
+BRAVE_API_KEY = ""
 BRAVE_SEARCH_URL = "https://api.brave.com/res/v1/web/search"
 
 # Rate limits

--- a/data/school_schedules/archive/scripts/mega_scraper_v2.py
+++ b/data/school_schedules/archive/scripts/mega_scraper_v2.py
@@ -31,7 +31,7 @@ NCES_ALL_FILE = BASE_DIR / "nces_all_districts.csv"
 MEGA_RESULTS_FILE = BASE_DIR / "mega_scraper_results.json"
 LOG_FILE = BASE_DIR / "mega_scraper.log"
 
-BRAVE_API_KEY = "BSAEB_N4ZkM3WOQN6bokdPKGkL6HWuN"
+BRAVE_API_KEY = ""
 BRAVE_SEARCH_URL = "https://api.brave.com/res/v1/web/search"
 
 BRAVE_DELAY = 1.1

--- a/data/school_schedules/archive/scripts/turbo_scraper.py
+++ b/data/school_schedules/archive/scripts/turbo_scraper.py
@@ -34,7 +34,7 @@ COMPREHENSIVE_FILE = BASE_DIR / "districts_comprehensive.csv"
 RESULTS_FILE = BASE_DIR / "turbo_scraper_results.json"
 LOG_FILE = BASE_DIR / "turbo_scraper.log"
 
-BRAVE_API_KEY = "BSAEB_N4ZkM3WOQN6bokdPKGkL6HWuN"
+BRAVE_API_KEY = ""
 BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search"
 FIRECRAWL_API_KEY = os.environ.get("FIRECRAWL_API_KEY", "")
 FIRECRAWL_SCRAPE_URL = "https://api.firecrawl.dev/v1/scrape"

--- a/data/school_schedules/state_doe_survey.py
+++ b/data/school_schedules/state_doe_survey.py
@@ -7,7 +7,7 @@ import time
 import requests
 import os
 
-BRAVE_API_KEY = os.environ.get("BRAVE_SEARCH_API_KEY", "BSAEB_N4ZkM3WOQN6bokdPKGkL6HWuN")
+BRAVE_API_KEY = os.environ.get("BRAVE_SEARCH_API_KEY")
 
 STATES = [
     "Alabama", "Alaska", "Arizona", "Arkansas", "California",

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Scan for hardcoded secrets in this repo and in the current users crontab.
+# Exits 1 if any are found. Usage:
+#   scripts/check-secrets.sh              # full scan of working tree + crontab
+#   scripts/check-secrets.sh --staged     # scan only staged diffs (pre-commit hook mode)
+#
+# Update patterns below when a new secret class is introduced.
+
+set -uo pipefail
+
+MODE="${1:-full}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+cd "$REPO_ROOT"
+
+PATTERNS=(
+    "sk-ant-api03-[A-Za-z0-9_-]{20,}"
+    "BSA[A-Za-z0-9_-]{20,}"
+    "fc-[a-f0-9]{32}"
+    "MT[A-Za-z0-9_-]{22,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}"
+    "discord(app)?\.com/api/webhooks/[0-9]+/[A-Za-z0-9_-]+"
+    "sk_live_[A-Za-z0-9]{24,}"
+    "sk_test_[A-Za-z0-9]{24,}"
+)
+
+FILE_GLOBS=(--include="*.sh" --include="*.py" --include="*.js" --include="*.ts" --include="*.json" --include="*.yaml" --include="*.yml" --include="*.env" --include="*.conf" --include="*.toml")
+EXCLUDE_DIRS=(--exclude-dir=".venv" --exclude-dir="venv" --exclude-dir="node_modules" --exclude-dir=".git" --exclude-dir="__pycache__" --exclude-dir="dist" --exclude-dir="build" --exclude-dir=".tox" --exclude-dir=".mypy_cache" --exclude-dir=".pytest_cache")
+
+FOUND=0
+
+scan_tree() {
+    echo "Scanning working tree..."
+    for p in "${PATTERNS[@]}"; do
+        local m
+        m=$(grep -rnE "$p" "${FILE_GLOBS[@]}" "${EXCLUDE_DIRS[@]}" . 2>/dev/null | grep -v "scripts/check-secrets.sh" | grep -v "check-secrets-hook" || true)
+        if [ -n "$m" ]; then
+            echo "FAIL pattern: $p"
+            echo "$m" | head -25
+            FOUND=1
+        fi
+    done
+}
+
+scan_crontab() {
+    echo "Scanning crontab -l..."
+    local cron
+    if cron=$(crontab -l 2>/dev/null); then
+        for p in "${PATTERNS[@]}"; do
+            local m
+            m=$(echo "$cron" | grep -nE "$p" || true)
+            if [ -n "$m" ]; then
+                echo "FAIL crontab pattern: $p"
+                echo "$m"
+                FOUND=1
+            fi
+        done
+    else
+        echo "(no crontab for $USER)"
+    fi
+}
+
+scan_staged() {
+    echo "Scanning staged diff..."
+    local staged
+    staged=$(git diff --cached --name-only --diff-filter=ACM -- "*.sh" "*.py" "*.js" "*.ts" "*.json" "*.yaml" "*.yml" "*.env" "*.conf" "*.toml" 2>/dev/null || true)
+    if [ -z "$staged" ]; then
+        echo "(no staged code/config files)"
+        return
+    fi
+    local f p m
+    for f in $staged; do
+        [[ "$f" == *"check-secrets.sh" ]] && continue
+        for p in "${PATTERNS[@]}"; do
+            m=$(git show ":$f" 2>/dev/null | grep -nE "$p" || true)
+            if [ -n "$m" ]; then
+                echo "FAIL $f pattern: $p"
+                echo "$m" | head -10
+                FOUND=1
+            fi
+        done
+    done
+}
+
+case "$MODE" in
+    --staged|staged)
+        scan_staged
+        ;;
+    *)
+        scan_tree
+        scan_crontab
+        ;;
+esac
+
+if [ "$FOUND" -eq 1 ]; then
+    echo
+    echo "Hardcoded secrets detected. Move values to env vars (~/.bashrc or ~/.env) and reference via os.environ / \$VAR."
+    exit 1
+fi
+
+echo "No hardcoded secrets detected."
+exit 0


### PR DESCRIPTION
## Context
ops#27 remediation. Cleans up hardcoded `BRAVE_API_KEY` literals that exist on `origin/main` in `data/school_schedules/` scripts. Adds a stronger secret scanner for local/manual use and as a pre-commit hook.

Companion PR: `hazeydata/data-hub` — removes the same literal + hardcoded `ANTHROPIC_API_KEY` and `FIRECRAWL_API_KEY` from `pipelines/ssd/run_sprint2_nightly.sh`.

## Changes (7 files)
- `data/school_schedules/state_doe_survey.py` — null the `os.environ.get("BRAVE_SEARCH_API_KEY", <LITERAL>)` fallback.
- `data/school_schedules/archive/scripts/improved_scraper_test.py` — same pattern.
- `data/school_schedules/archive/scripts/{mega_scraper, mega_scraper_v2, mass_scraper, mass_scraper_v2, turbo_scraper}.py` — replace direct-assignment literal with empty string. Archive dir preserved per Fred's call.

**Added:** `scripts/check-secrets.sh` — scans the working tree + `crontab -l` for Anthropic, Brave, Firecrawl, Discord (bot tokens + webhooks), and Stripe key patterns. `--staged` mode for pre-commit hook use. Excludes `.venv/`, `node_modules/`, `__pycache__/`, etc.

## Verification
- `python3 -m py_compile` → OK on all 7 modified `.py` files.
- `git grep -E "BSAEB_|sk-ant-api03-|fc-[a-f0-9]{32}"` on this branch → clean.
- `scripts/check-secrets.sh` run against this branch → clean.
- `bash -n scripts/check-secrets.sh` → OK.
- Pre-commit hook smoke-tested: fake-secret addition blocked; empty-string assignment passes.

## Pre-commit hook (wilma-server)
A self-contained pre-commit hook has been installed in the wilma-server clone for this repo (also for data-hub and operations). It's deliberately not tracked in the repo (hooks are local by design) and checks only *added* lines in the staged diff so secret-removal commits aren't falsely blocked.

## Context note — Wilma's commit `53bdf0cf`
There's an unpushed local-only commit on wilma-server titled _"Security fix: Remove hardcoded API keys from shell scripts — Add check-secrets.sh"_ that claims to do this work. Its actual diff only touches `docs/analytics-data/*.json` — no `.sh` or `.py` edits, no `check-secrets.sh` creation. Flagged for context; **this** PR does the work the message claimed. No further investigation per Fred's direction.

## Pending actions (Fred)
- [ ] Review + merge this PR and the companion data-hub PR.
- [ ] **Rotate the Brave Search API key** at the provider — the exposed literal is in git history on `origin/main` and rotation is required independent of this cleanup.
- [ ] Update `~/.bashrc` on wilma-server with the rotated value.
- [ ] Close `hazeydata/operations#27` only after merges + rotation complete.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
