### PR TITLE
#470: Promote xgb-dow to baseline (day_of_week as 6th feature)

### DIFF
--- a/pipeline/steps/s07_training.py
+++ b/pipeline/steps/s07_training.py
@@ -2,12 +2,13 @@
 
 === V4 DESIGN PRINCIPLE: ONE MODEL PER ENTITY ===
 
-The baseline pipeline trains ONE XGBoost model per entity using 5 features:
+The baseline pipeline trains ONE XGBoost model per entity using 6 features:
   - mins_since_6am
   - mins_since_open
   - date_group_id_encoded
   - season_encoded
   - season_year_encoded
+  - day_of_week  (promoted from xgb-dow challenger, TPCR #470, 2026-04-22)
 
 No multi-candidate selection. No posted_time features. No lite fallback.
 The baseline is the simplest thing that works.
@@ -48,6 +49,7 @@ BASELINE_FEATURES = [
     "date_group_id_encoded",
     "season_encoded",
     "season_year_encoded",
+    "day_of_week",
 ]
 
 
@@ -168,6 +170,10 @@ def _train_baseline_model(
 
     if len(entity_df) < min_samples:
         return None
+
+    # Compute derived features if requested but not in data
+    if "day_of_week" in BASELINE_FEATURES and "day_of_week" not in entity_df.columns:
+        entity_df["day_of_week"] = pd.to_datetime(entity_df["park_date"]).dt.dayofweek.astype(np.float32)
 
     # Validate features exist
     missing = [f for f in BASELINE_FEATURES if f not in entity_df.columns]

--- a/pipeline/steps/s08_forecast.py
+++ b/pipeline/steps/s08_forecast.py
@@ -42,6 +42,7 @@ from pipeline.core.validation import ValidationError, require_file
 FEATURES_BASELINE = [
     "mins_since_6am", "mins_since_open",
     "date_group_id_encoded", "season_encoded", "season_year_encoded",
+    "day_of_week",
 ]
 FEATURES_LITE = ["mins_since_6am", "mins_since_open"]
 FEATURES_LEGACY_V2 = [
@@ -54,7 +55,7 @@ FEATURES_LEGACY_V2 = [
 ALL_POSSIBLE_FEATURES = [
     "mins_since_6am", "mins_since_open",
     "date_group_id_encoded", "season_encoded", "season_year_encoded",
-    "posted_time", "hour_of_day",
+    "posted_time", "hour_of_day", "day_of_week",
 ]
 
 
@@ -234,6 +235,13 @@ def _forecast_entity_fast(
 
     df = time_grid.copy()
     df["entity_code"] = entity_code
+
+    # Compute derived features if requested but not in data
+    # (Kept at top of function so DOW is present for every model path, incl. the
+    # meta_features check at L284 which would silently fall back to 5-feature
+    # baseline if day_of_week were missing after retrain.)
+    if "day_of_week" in FEATURES_BASELINE and "day_of_week" not in df.columns:
+        df["day_of_week"] = pd.to_datetime(df["park_date"]).dt.dayofweek.astype(np.float32)
 
     # O(1) operating calendar filter
     if oc_by_entity is not None:


### PR DESCRIPTION
Closes #470.

Promotes the `xgb-dow` challenger (day_of_week as 6th feature) to the production baseline. Barney approved post proof-batch + F4 diagnosis. Full retrain runs automatically on tomorrow's 6 AM ET cron.

## Changes

**`pipeline/steps/s07_training.py`**
- `BASELINE_FEATURES`: append `day_of_week` (6th).
- `_train_baseline_model`: inline DOW compute right after `entity_df.reset_index(drop=True)` — mirrors `pipeline/competition/train_challenger.py:70-71` exactly (`pd.to_datetime(...).dt.dayofweek.astype(np.float32)`).
- Top docstring: 5 → 6 features.

**`pipeline/steps/s08_forecast.py`**
- `FEATURES_BASELINE`: append `day_of_week`.
- `ALL_POSSIBLE_FEATURES`: append `day_of_week` for catalog consistency.
- `_forecast_entity_fast`: inline DOW compute at the **top** of the function, right after `df["entity_code"] = entity_code`. This is critical — the meta-aware feature check at what is now L292 would otherwise fall back to 5-feature inference when new models' `metadata_baseline.json` lists `day_of_week`, silently reverting the promotion on the forecast side.

Py-compile verified. Branch built from fresh clone of origin/main to avoid Wilma's local divergence.

## Proof batch

15 entities across MK/EP/IA/DL/TDL/TDS (IA substituted for UF — `UF.parquet` doesn't exist in production training data; Barney accepted).

- **11 improved, 4 regressed by strict sign**
- 3 of 4 "regressions" are <|0.05| MAE — statistical tie territory (MK05 -0.027, IA08 -0.037, DL13 -0.012)
- **1 real regression: MK162** (-0.941, 22k samples — edge low-volume; matches expected risk profile for the TD-tier)
- **Volume-weighted mean Δ = +0.045 MAE**
- EP09 max|Δ|30d = 35 min on Fri 2026-05-22 19:00 (Memorial Day weekend) — historical actuals on late-May Fridays @ 19:00 are 8-38 min range, new model (30 min) sits inside that range, old model (65 min) was 3× above observed ceiling. Promotion is net-correcting a systematic Friday-leaking-into-Saturday over-prediction via `date_group_id_encoded`.

Full proof batch rows, OOM diagnosis, and F4 slot diagnosis in the #470 conversation thread.

## Rollback

- Pre-promotion code tag: `pre-xgb-dow-promotion-20260414-1331`
- Pre-promotion model archive: existed per Barney's S34 note; exact disk path not visible in my fresh clone — Wilma to confirm location or reshare if needed.
- Rollback procedure if 7-day rolling MAE worsens vs pre-promotion 8.4 baseline: `git revert` this merge + restore archived `model_baseline.json` files.

## Out of scope (filed separately per Barney)

- `#475` (to file) — s07 column-prune + categorical dtype for the parquet-load OOM (root cause confirmed on MK at 10.4 GB RSS; fix pattern verified in proof-batch harness dropping to 5.1 GB).
- `#476` (to file) — s08 `_forecast_entity_fast` returning `None` on both old and new model dirs for MK162 + EP18 (unrelated to this promotion).
- Follow-up commit on a separate branch — remove `pipeline/competition/challengers/xgb_dow.py` from active shadow registry (it IS the baseline now; redundant but harmless short-term).
- Doc updates (`PIPELINE_V4_DESIGN.md`, `MODELING_AND_WTI_METHODOLOGY.md`, `SESSION_LOG.md`) after 3 clean days of post-promotion observed MAE.

## Watch

MK162 on a post-promotion watchlist: 7-day rolling MAE vs pre-promotion, auto-rollback trigger if sustained Δ > +1.0 MAE for 2+ days. Implementation proposal in the #470 comment.

🪨 Barney approved for merge. Tomorrow's 6 AM cron untouched.