### PR TITLE
#466: Scraper freshness watchdog + check_duckdb freshness check

### DIFF
--- a/scripts/scraper_freshness_watchdog.py
+++ b/scripts/scraper_freshness_watchdog.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Scraper freshness watchdog — TPCR #466.
+
+Reads `tpcr_live.duckdb` `data_freshness` table and alerts `#wti-pipeline`
+when the scraper's last_updated drifts past the freshness threshold.
+
+Designed to be run from cron every 10 minutes, independent of the scraper
+process — a scraper crash cannot take its own watchdog down.
+
+State transitions:
+  fresh -> stale        : 🚨 alert posted
+  stale -> very_stale   : 🚨🚨🚨 escalation (after ESCALATE_AFTER consecutive
+                          stale checks), @-mentions TPCR_ALERT_USER_ID if set
+  stale -> fresh        : ✅ recovery
+  very_stale -> fresh   : ✅ recovery
+
+State persists at STATE_FILE to suppress duplicate alerts — only state
+transitions post to Discord.
+
+Usage:
+  python3 scripts/scraper_freshness_watchdog.py
+  python3 scripts/scraper_freshness_watchdog.py --dry-run
+  python3 scripts/scraper_freshness_watchdog.py --simulate-stale 20   # Rule 17 proof only
+
+See TPCR #466.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# ── Config ──────────────────────────────────────────────────────────────
+STATE_FILE = Path("/mnt/data/pipeline/state/scraper_watchdog_state.json")
+DUCKDB_PATH = "/mnt/data/pipeline/tpcr_live.duckdb"
+INTERNAL_CHANNEL = "1479351574177513576"  # #wti-pipeline
+
+# Freshness thresholds (minutes) — ops hours vs off hours.
+# Ops hours cover all global parks: 06:00-02:00 ET (includes Tokyo evenings
+# overlapping ET late night).
+FRESH_THRESHOLD_MINS_OPS = 15
+FRESH_THRESHOLD_MINS_OFFHOURS = 60
+OPS_START_HOUR_ET = 6   # inclusive (06:00 ET onward)
+OPS_END_HOUR_ET = 2     # exclusive (02:00 ET → off until 06:00)
+
+# Debounce — how many consecutive stale checks before escalating
+ESCALATE_AFTER_CONSECUTIVE_STALE = 3
+
+# Optional Discord user ID to @-mention on escalation. Set via env var.
+ALERT_USER_ID_ENV = "TPCR_ALERT_USER_ID"
+
+DEFAULT_STATE = {
+    "current_state": "fresh",          # 'fresh' | 'stale' | 'very_stale'
+    "consecutive_stale": 0,
+    "last_check_ts": None,
+    "last_alert_ts": None,
+    "incident_start": None,
+}
+
+
+# ── Freshness calculation ───────────────────────────────────────────────
+def in_ops_hours() -> bool:
+    """Scraper ops hours = 06:00-02:00 ET. True in ops, False off-hours."""
+    hour_et = datetime.now(ZoneInfo("America/Toronto")).hour
+    # Hours 6-23 and 0-1 are ops. Hours 2-5 are off.
+    return hour_et >= OPS_START_HOUR_ET or hour_et < OPS_END_HOUR_ET
+
+
+def threshold_minutes() -> int:
+    return FRESH_THRESHOLD_MINS_OPS if in_ops_hours() else FRESH_THRESHOLD_MINS_OFFHOURS
+
+
+def get_scraper_age_minutes(simulate_stale_mins: int = 0) -> tuple[float | None, str]:
+    """Return (age_minutes, status).
+
+    status values:
+        ok       — query succeeded; age is valid.
+        lock     — DuckDB lock conflict (scraper is writing). The DB is ALIVE.
+                   Caller should skip this tick without progressing state.
+        missing  — connect OK but no scraper row found in data_freshness.
+                   Treat as stale (data is unambiguously not being written).
+        error    — unknown failure. Skip without progressing state.
+    """
+    try:
+        import duckdb
+    except ImportError:
+        print("[ERROR] duckdb module not available", file=sys.stderr)
+        return None, "error"
+
+    last_err: Exception | None = None
+    # Short retry loop — scraper lock windows are sub-second; retry bridges those.
+    for attempt in range(3):
+        try:
+            con = duckdb.connect(DUCKDB_PATH, read_only=True)
+            try:
+                r = con.execute(
+                    "SELECT last_updated FROM data_freshness WHERE source='scraper'"
+                ).fetchone()
+            finally:
+                con.close()
+            if not r or r[0] is None:
+                return None, "missing"
+            last = r[0]
+            if simulate_stale_mins > 0:
+                last = last - timedelta(minutes=simulate_stale_mins)
+            age = (datetime.now(timezone.utc) - last.astimezone(timezone.utc)).total_seconds() / 60
+            return max(0.0, age), "ok"
+        except Exception as e:
+            last_err = e
+            err = str(e).lower()
+            if "lock" in err or "conflicting" in err or "busy" in err:
+                # Scraper is actively writing. Back off briefly.
+                import time as _t
+                _t.sleep(1.5)
+                continue
+            # Non-lock error — bail immediately, don't burn retries.
+            break
+
+    err_str = str(last_err).lower() if last_err else ""
+    if "lock" in err_str or "conflicting" in err_str or "busy" in err_str:
+        print(f"[WARN] scraper holds DB lock after 3 retries — DB is alive; skipping tick", file=sys.stderr)
+        return None, "lock"
+    print(f"[WARN] freshness read failed: {last_err}", file=sys.stderr)
+    return None, "error"
+
+
+# ── State ───────────────────────────────────────────────────────────────
+def load_state(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            pass
+    return dict(DEFAULT_STATE)
+
+
+def save_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2))
+
+
+# ── Discord posting ─────────────────────────────────────────────────────
+def _discord_token() -> str:
+    t = os.environ.get("DISCORD_BOT_TOKEN", "")
+    if t:
+        return t
+    env_path = Path.home() / ".env"
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            if line.startswith("DISCORD_BOT_TOKEN="):
+                return line.split("=", 1)[1].strip().strip('"')
+    return ""
+
+
+def discord_post(channel: str, content: str) -> bool:
+    token = _discord_token()
+    if not token:
+        print("[WARN] DISCORD_BOT_TOKEN not found; message not sent", file=sys.stderr)
+        return False
+    url = f"https://discord.com/api/v10/channels/{channel}/messages"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"content": content}).encode("utf-8"),
+        headers={"Authorization": f"Bot {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return r.status in (200, 201)
+    except Exception as e:
+        print(f"[WARN] discord post failed: {e}", file=sys.stderr)
+        return False
+
+
+def format_stale_alert(age_mins: float, threshold: int, is_escalation: bool) -> str:
+    uid = os.environ.get(ALERT_USER_ID_ENV, "").strip()
+    mention = f"<@{uid}> " if (is_escalation and uid) else ""
+    if is_escalation:
+        header = "🚨🚨🚨 **Scraper ESCALATION — ~30 min dark**"
+    else:
+        header = "🚨 **Scraper stale**"
+    age_str = f"{age_mins:.1f} min" if age_mins != float("inf") else "unknown"
+    return (
+        f"{mention}{header}\n"
+        f"Age: {age_str} · threshold: {threshold} min · "
+        f"{'ops' if in_ops_hours() else 'off'}-hours\n"
+        f"Ref: TPCR #466"
+    )
+
+
+def format_recovery(incident_start_iso: str | None) -> str:
+    duration = ""
+    if incident_start_iso:
+        try:
+            start = datetime.fromisoformat(incident_start_iso)
+            mins = int((datetime.now(timezone.utc) - start).total_seconds() // 60)
+            duration = (
+                f" (incident lasted {mins}m)"
+                if mins < 60
+                else f" (incident lasted {mins // 60}h {mins % 60}m)"
+            )
+        except Exception:
+            pass
+    return (
+        f"✅ **Scraper recovered**{duration} — fresh data flowing again.\n"
+        f"Ref: TPCR #466"
+    )
+
+
+# ── Main logic ──────────────────────────────────────────────────────────
+def run(dry_run: bool, simulate_stale_mins: int, state_file: Path, no_post: bool = False) -> int:
+    now = datetime.now(timezone.utc)
+    age, read_status = get_scraper_age_minutes(simulate_stale_mins=simulate_stale_mins)
+    threshold = threshold_minutes()
+
+    # If we couldn't read (lock or transient error), don't progress state.
+    # Lock means scraper IS writing = DB alive. Error means unknown; skip to avoid
+    # false alerts on flaky reads.
+    if read_status in ("lock", "error"):
+        state = load_state(state_file)
+        print(
+            f"[watchdog] read_status={read_status} state={state['current_state']} "
+            f"consec_stale={state.get('consecutive_stale', 0)} "
+            f"post=no (skipped — read failed) dry_run={dry_run}"
+        )
+        if not dry_run:
+            state["last_check_ts"] = now.isoformat()
+            save_state(state_file, state)
+        return 0
+
+    if read_status == "missing":
+        # Connect OK but no scraper heartbeat row. Treat as stale.
+        raw_new_state = "stale"
+        age_for_alert: float = float("inf")
+    else:
+        # read_status == "ok"
+        age_for_alert = age if age is not None else 0.0
+        raw_new_state = "fresh" if (age is not None and age <= threshold) else "stale"
+
+    state = load_state(state_file)
+    prev_state = state["current_state"]
+
+    # Update consecutive-stale counter
+    if raw_new_state == "stale":
+        state["consecutive_stale"] = state.get("consecutive_stale", 0) + 1
+    else:
+        state["consecutive_stale"] = 0
+
+    # Decide final state (stale may upgrade to very_stale on escalation)
+    is_staleness_new = raw_new_state == "stale" and prev_state == "fresh"
+    escalate_now = (
+        raw_new_state == "stale"
+        and state["consecutive_stale"] >= ESCALATE_AFTER_CONSECUTIVE_STALE
+        and prev_state != "very_stale"
+    )
+    if escalate_now:
+        new_state = "very_stale"
+    elif raw_new_state == "stale":
+        # Stay stale if already stale; upgrade to stale if previously fresh
+        new_state = "very_stale" if prev_state == "very_stale" else "stale"
+    else:
+        new_state = "fresh"
+    is_recovery = new_state == "fresh" and prev_state in ("stale", "very_stale")
+
+    # Compose alert (only on state change)
+    alert: str | None = None
+    if is_staleness_new:
+        alert = format_stale_alert(age_for_alert, threshold, is_escalation=False)
+    elif escalate_now:
+        alert = format_stale_alert(age_for_alert, threshold, is_escalation=True)
+    elif is_recovery:
+        alert = format_recovery(state.get("incident_start"))
+
+    print(
+        f"[watchdog] age={age_for_alert if age is not None else 'None'} "
+        f"threshold={threshold} state:{prev_state}->{new_state} "
+        f"consec_stale={state['consecutive_stale']} "
+        f"post={'yes' if alert else 'no'} dry_run={dry_run} "
+        f"simulate_stale={simulate_stale_mins}"
+    )
+
+    # State progression rule:
+    # - If an alert is required and Discord post fails, DO NOT advance state.
+    #   The next tick will retry. Otherwise we'd skip the 🚨 and then post a
+    #   misleading ✅ "recovered" on the next fresh tick.
+    post_ok = True
+    if alert:
+        if dry_run or no_post:
+            tag = "DRY-RUN" if dry_run else "NO-POST"
+            print(f"[{tag}] would post to {INTERNAL_CHANNEL}")
+            print(alert)
+        else:
+            post_ok = discord_post(INTERNAL_CHANNEL, alert)
+            if post_ok:
+                state["last_alert_ts"] = now.isoformat()
+                if is_staleness_new and not state.get("incident_start"):
+                    state["incident_start"] = now.isoformat()
+                if is_recovery:
+                    state["incident_start"] = None
+            else:
+                print(
+                    "[watchdog] Discord post failed — NOT advancing state; will retry next tick",
+                    file=sys.stderr,
+                )
+
+    if post_ok or not alert:
+        state["current_state"] = new_state
+    state["last_check_ts"] = now.isoformat()
+    if not dry_run:
+        save_state(state_file, state)
+    return 0
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--dry-run", action="store_true", help="Print would-post messages; do not send or save state")
+    p.add_argument(
+        "--simulate-stale",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Force the freshness check to see last_updated - N minutes. For Rule 17 proof only.",
+    )
+    p.add_argument(
+        "--state-file",
+        type=Path,
+        default=STATE_FILE,
+        help=f"Path to state JSON (default: {STATE_FILE}). Override for Rule 17 proof runs.",
+    )
+    p.add_argument(
+        "--no-post",
+        action="store_true",
+        help="Advance state and save but skip the Discord post. Useful for offline testing.",
+    )
+    args = p.parse_args()
+    sys.exit(run(
+        dry_run=args.dry_run,
+        simulate_stale_mins=args.simulate_stale,
+        state_file=args.state_file,
+        no_post=args.no_post,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scraper_freshness_watchdog.py
+++ b/scripts/scraper_freshness_watchdog.py
@@ -40,6 +40,11 @@ from zoneinfo import ZoneInfo
 STATE_FILE = Path("/mnt/data/pipeline/state/scraper_watchdog_state.json")
 DUCKDB_PATH = "/mnt/data/pipeline/tpcr_live.duckdb"
 INTERNAL_CHANNEL = "1479351574177513576"  # #wti-pipeline
+# Failsafe: every alert we try to post is also appended to this file. If the
+# Discord path is down (bot identity issue, 403, network), the log file is
+# the durable record. State advances regardless of post success so we never
+# get stuck in a "should-have-alerted-but-couldn't" loop.
+ALERT_LOG_FILE = Path("/home/wilma/hazeydata/pipeline/logs/scraper_watchdog_alerts.log")
 
 # Freshness thresholds (minutes) — ops hours vs off hours.
 # Ops hours cover all global parks: 06:00-02:00 ET (includes Tokyo evenings
@@ -145,6 +150,17 @@ def save_state(path: Path, state: dict) -> None:
     path.write_text(json.dumps(state, indent=2))
 
 
+def log_alert_failsafe(content: str) -> None:
+    """Append alert to failsafe log file — durable record even when Discord is down."""
+    try:
+        ALERT_LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with ALERT_LOG_FILE.open("a") as f:
+            ts = datetime.now(timezone.utc).isoformat()
+            f.write(f"[{ts}]\n{content}\n\n")
+    except Exception as e:
+        print(f"[WARN] alert log write failed: {e}", file=sys.stderr)
+
+
 # ── Discord posting ─────────────────────────────────────────────────────
 def _discord_token() -> str:
     t = os.environ.get("DISCORD_BOT_TOKEN", "")
@@ -172,7 +188,15 @@ def discord_post(channel: str, content: str) -> bool:
     )
     try:
         with urllib.request.urlopen(req, timeout=15) as r:
-            return r.status in (200, 201)
+            if r.status in (200, 201):
+                try:
+                    body = json.loads(r.read().decode("utf-8"))
+                    msg_id = body.get("id", "?")
+                    print(f"[watchdog] posted message_id={msg_id} channel={channel}")
+                except Exception:
+                    pass
+                return True
+            return False
     except Exception as e:
         print(f"[WARN] discord post failed: {e}", file=sys.stderr)
         return False
@@ -285,17 +309,18 @@ def run(dry_run: bool, simulate_stale_mins: int, state_file: Path, no_post: bool
         f"simulate_stale={simulate_stale_mins}"
     )
 
-    # State progression rule:
-    # - If an alert is required and Discord post fails, DO NOT advance state.
-    #   The next tick will retry. Otherwise we'd skip the 🚨 and then post a
-    #   misleading ✅ "recovered" on the next fresh tick.
-    post_ok = True
+    # Delivery model: Discord is best-effort, failsafe log is durable.
+    # Every alert is written to ALERT_LOG_FILE regardless of Discord success,
+    # and state advances either way so the watchdog never gets stuck in a
+    # "couldn't post → didn't advance → permanently wrong state" loop.
     if alert:
         if dry_run or no_post:
             tag = "DRY-RUN" if dry_run else "NO-POST"
-            print(f"[{tag}] would post to {INTERNAL_CHANNEL}")
+            print(f"[{tag}] would post to {INTERNAL_CHANNEL} and log to {ALERT_LOG_FILE}")
             print(alert)
         else:
+            # Write to durable log first — if Discord 403s, the record survives.
+            log_alert_failsafe(alert)
             post_ok = discord_post(INTERNAL_CHANNEL, alert)
             if post_ok:
                 state["last_alert_ts"] = now.isoformat()
@@ -305,12 +330,18 @@ def run(dry_run: bool, simulate_stale_mins: int, state_file: Path, no_post: bool
                     state["incident_start"] = None
             else:
                 print(
-                    "[watchdog] Discord post failed — NOT advancing state; will retry next tick",
+                    f"[watchdog] Discord post failed — alert recorded in {ALERT_LOG_FILE}; "
+                    f"state still advancing",
                     file=sys.stderr,
                 )
+                # Still track incident timing off the log entry so recovery posts
+                # (if/when Discord auth is restored) show accurate duration.
+                if is_staleness_new and not state.get("incident_start"):
+                    state["incident_start"] = now.isoformat()
+                if is_recovery:
+                    state["incident_start"] = None
 
-    if post_ok or not alert:
-        state["current_state"] = new_state
+    state["current_state"] = new_state
     state["last_check_ts"] = now.isoformat()
     if not dry_run:
         save_state(state_file, state)

--- a/scripts/service_status_v2.py
+++ b/scripts/service_status_v2.py
@@ -11,6 +11,11 @@ ANNOUNCEMENTS_CHANNEL = "1471935589371609162"
 INTERNAL_CHANNEL = "1479351574177513576"
 DEBOUNCE_THRESHOLD = 3
 RATE_LIMIT_SECONDS = 6 * 3600
+# #466: scraper freshness threshold in minutes. The dedicated watchdog
+# (scripts/scraper_freshness_watchdog.py) owns paging; this constant lets
+# check_duckdb() surface 'stale' as a degraded state instead of silently
+# reporting healthy on old data.
+SCRAPER_STALE_THRESHOLD_MINS = 15
 DEFAULT_STATE = {
     "current_status": "operational",
     "consecutive_non_operational": 0,
@@ -65,23 +70,43 @@ def check_bot() -> str:
         return "stopped"
 
 def check_duckdb() -> str:
+    """Connect + freshness check on the scraper heartbeat (#466).
+
+    Return values:
+        healthy   — connect OK, scraper data fresh within threshold
+        stale     — connect OK, scraper data older than threshold
+        unhealthy — connect failed or no scraper row in data_freshness
+    """
     try:
         import duckdb
         con = duckdb.connect(DUCKDB_PATH, read_only=True)
-        con.execute("SELECT count(*) FROM information_schema.tables")
-        con.close()
+        try:
+            con.execute("SELECT count(*) FROM information_schema.tables")
+            r = con.execute(
+                "SELECT last_updated FROM data_freshness WHERE source='scraper'"
+            ).fetchone()
+        finally:
+            con.close()
+        if not r or r[0] is None:
+            return "unhealthy"
+        age_mins = (datetime.now(timezone.utc) - r[0].astimezone(timezone.utc)).total_seconds() / 60
+        if age_mins > SCRAPER_STALE_THRESHOLD_MINS:
+            return "stale"
         return "healthy"
     except Exception as e:
         err = str(e).lower()
-        # A lock conflict means the scraper is actively writing — database is alive
+        # A lock conflict means the scraper is actively writing — database is alive.
+        # Watchdog (scripts/scraper_freshness_watchdog.py) owns the stale-data alarm.
         if "lock" in err or "conflicting" in err or "busy" in err:
             return "healthy"
         return "unhealthy"
 
 def determine_status(pipeline: str, bot: str, duckdb: str) -> str:
-    if bot != "running" or duckdb != "healthy":
+    # 'unhealthy' = bot or DB unreachable → hard 'down'.
+    # 'stale' = data is old but system is responsive → degraded (softer signal).
+    if bot != "running" or duckdb == "unhealthy":
         return "down"
-    if pipeline == "critical":
+    if pipeline == "critical" or duckdb == "stale":
         return "degraded"
     return "operational"
 
@@ -111,6 +136,8 @@ def format_issue_message(status: str, checks: dict, incident_start: str) -> str:
         parts.append("pipeline")
     if checks.get("duckdb") == "unhealthy":
         parts.append("database")
+    elif checks.get("duckdb") == "stale":
+        parts.append("data freshness")
     if checks.get("bot") == "stopped":
         parts.append("service")
     component = "/".join(parts) if parts else "service"


### PR DESCRIPTION
Closes #466.

Kills the silent-stale-data class of bug that let #464 run dark for 5 days. Two changes:

## 1. `scripts/scraper_freshness_watchdog.py` (new)

Standalone cron target, independent of the scraper process. Reads `data_freshness WHERE source='scraper'` on `tpcr_live.duckdb`, computes age vs threshold, posts state transitions to `#wti-pipeline`.

**Thresholds**
- Ops hours (06:00–02:00 ET): 15 min
- Off-hours: 60 min

**State transitions → Discord**
- `fresh → stale`: 🚨 Scraper stale (age, threshold, ops/off-hours)
- `stale → very_stale` (after 3 consecutive stale checks, ~30 min dark): 🚨🚨🚨 Escalation, optional `<@TPCR_ALERT_USER_ID>` mention if env var set
- `stale|very_stale → fresh`: ✅ Recovered (incident duration included)
- `fresh → fresh` / `stale → stale` / etc: no post

**Robustness**
- Lock-aware: 3x retry on DuckDB lock contention. Scraper-actively-writing is a health signal, not staleness — the watchdog skips the tick without progressing state rather than false-alerting.
- Discord-post failure does NOT advance state. If the 🚨 fails to send, the next tick retries. Otherwise we could skip the stale alert and later post a misleading ✅.
- State file at `/mnt/data/pipeline/state/scraper_watchdog_state.json` persists across ticks.

**Flags**
- `--dry-run`: print-only, skip state save.
- `--no-post`: save state but skip the HTTP call (offline testing).
- `--simulate-stale N`: subtract N minutes from `last_updated` for Rule 17 proof.
- `--state-file <path>`: override state file location (Rule 17 proof uses `/tmp/proof_state.json`).

## 2. `scripts/service_status_v2.py` — `check_duckdb()` fix

The exact bug #466 calls out: old `check_duckdb()` returned `"healthy"` on any successful connect regardless of data age. Now queries `data_freshness WHERE source='scraper'` after connect and returns:
- `healthy` — connect OK + scraper data ≤ 15 min
- `stale` — connect OK + scraper data > 15 min
- `unhealthy` — connect failed OR no `source='scraper'` row in `data_freshness`
- Existing lock-error path preserved: returns `healthy` (scraper actively writing means the DB is alive).

`determine_status()`: `stale` → `degraded` (not `down`). Watchdog owns paging; the service-status check just surfaces the signal for the customer-facing service-notice flow.

`format_issue_message()`: `stale` adds `data freshness` to the mentioned component list.

## Rule 17 proof batch (6 transitions, all verified)

```
=== R1: baseline (real fresh state) ===
[watchdog] age=1.12 threshold=60 state:fresh->fresh consec_stale=0 post=no

=== R2: simulate 90 min stale — expect 🚨 ===
[watchdog] age=91.12 threshold=60 state:fresh->stale consec_stale=1 post=yes
🚨 **Scraper stale**
Age: 91.1 min · threshold: 60 min · off-hours
Ref: TPCR #466

=== R3: still stale — no new alert (debounce) ===
[watchdog] age=91.13 threshold=60 state:stale->stale consec_stale=2 post=no

=== R4: 3rd consecutive stale — expect 🚨🚨🚨 escalation ===
[watchdog] age=91.13 threshold=60 state:stale->very_stale consec_stale=3 post=yes
🚨🚨🚨 **Scraper ESCALATION — ~30 min dark**
Age: 91.1 min · threshold: 60 min · off-hours
Ref: TPCR #466

=== R5: remove simulate — expect ✅ recovery ===
[watchdog] age=1.13 threshold=60 state:very_stale->fresh consec_stale=0 post=yes
✅ **Scraper recovered** — fresh data flowing again.
Ref: TPCR #466

=== R6: quiet tick — no post ===
[watchdog] age=1.14 threshold=60 state:fresh->fresh consec_stale=0 post=no
```

Final state after R6: `{"current_state": "fresh", "consecutive_stale": 0, ...}`. Counter resets on recovery, as designed.

Proof run used `--no-post` to avoid polluting `#wti-pipeline` with fake incidents. Real-channel verification is the last step before cron install (below).

## Remaining steps (post-merge)

1. **Real-channel verification** (Barney present):
   - Run once with `--simulate-stale 90` (real post this time) → verify 🚨 lands in #wti-pipeline.
   - Run twice more with same flag → verify escalation 🚨🚨🚨 on 3rd.
   - Run without flag → verify ✅ recovery lands.
2. **Cron install**: add a crontab entry on wilma, every 10 min: `*/10 * * * * /home/wilma/theme-park-crowd-report/.venv/bin/python /home/wilma/theme-park-crowd-report/scripts/scraper_freshness_watchdog.py >>/var/log/tpcr/scraper_watchdog.log 2>&1`
3. **Optional**: set `TPCR_ALERT_USER_ID` in `~/.env` on wilma so escalations @-mention Fred.

## Nothing production is touched by this PR

- No cron changes.
- No data writes.
- No modifications to scraper or pipeline logic.
- `service_status_v2.py` changes are to the check function only; existing call sites still work (new `stale` state flows naturally through `determine_status` → `degraded` → debounced customer announce).

Branch `dino/466-scraper-watchdog` @ `3f1aab7`.