### PR TITLE
#466 followup: Discord User-Agent header (fixes Cloudflare 403)

### DIFF
--- a/scripts/scraper_freshness_watchdog.py
+++ b/scripts/scraper_freshness_watchdog.py
@@ -183,7 +183,14 @@ def discord_post(channel: str, content: str) -> bool:
     req = urllib.request.Request(
         url,
         data=json.dumps({"content": content}).encode("utf-8"),
-        headers={"Authorization": f"Bot {token}", "Content-Type": "application/json"},
+        headers={
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+            # User-Agent is REQUIRED by Discord; without it, Cloudflare's WAF
+            # blocks urllib with HTTP 403 (CF error 1010). See post-merge
+            # discovery during #466 verification.
+            "User-Agent": "DiscordBot (https://github.com/hazeydata/theme-park-crowd-report, 1.0)",
+        },
         method="POST",
     )
     try:


### PR DESCRIPTION
Tiny followup to #476. Without a User-Agent, Cloudflare's WAF returns HTTP 403 error code 1010 on urllib-based POSTs to discord.com. My --no-post proof batch missed this; real-channel verify caught it.

Fix: add `User-Agent: DiscordBot (https://github.com/hazeydata/theme-park-crowd-report, 1.0)` in `discord_post`.

Verified: banner '[WATCHDOG VERIFY — TPCR #466]' posted successfully to #wti-pipeline with this header (message_id 1497420457840869428); same request without it → 403 CF 1010.

Also closes follow-up item 3 from #476 ('Dino bot identity / Discord permission wall') — not a bot-permission issue, just a header.

(Replaces closed PR #477 — original branch was based on pre-squash main, rebase/force-push blocked.)