### PR TITLE
ops #35: Add backup coordination lock file check to scraper

### DIFF
--- a/src/get_wait_times_from_queue_times.py
+++ b/src/get_wait_times_from_queue_times.py
@@ -925,6 +925,14 @@ def main() -> None:
             while True:
                 run += 1
                 logger.info(f"--- Run #{run} ---")
+                
+                # ops #35 - Check for backup lock file before any database operations
+                if os.path.exists('/tmp/b2_backup.lock'):
+                    logger.info("Backup in progress, skipping cycle")
+                    logger.info(f"Sleeping {args.interval}s...")
+                    time.sleep(args.interval)
+                    continue
+                
                 try:
                     total_rows = run_once()
                     if total_rows > 0:


### PR DESCRIPTION
Implements Option X backup coordination for ops #35.

Problem: 12 consecutive backup failures due to DuckDB file lock conflicts during scraper writes.

Solution: Add lock file check at top of scraper ingest cycle:
- Check before any DuckDB operations  
- Skip cycle if backup in progress
- Sleep until normal cadence, continue loop
- No retry logic, single check per spec

Testing: Requires proof batch with simulated DB activity before live deployment.

Links: 
- ops issue: https://github.com/hazeydata/operations/issues/35
- Backup script updated separately in operations repo

Review Notes: 
- Scraper has 21-day uptime record - minimal, safe change
- No signal handling modifications
- Lock file created/removed by backup script with trap cleanup