### PR TITLE
ops #96: Response Contract (Variant B) — TPCR CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,26 @@
 # Theme Park Crowd Report — AI Agent Guide
 
+<!-- response-contract v2 -->
+## Response Contract — hard rule, overrides all other formatting guidance
+
+Reasoning is internal. Report conclusions, never the path to them.
+
+Default shape for every reply:
+
+**TL;DR** — one line, <=25 words.
+**Next** — the single command, file, or decision Fred acts on. One item only.
+**Notes** — max 3 bullets, <=15 words each. Blockers, risks, surprises only.
+
+Hard caps:
+- <=120 words total outside code and diffs.
+- One topic per reply. Found something else? Hold it. Do not append it.
+- No preamble, no restating the question, no closing summary, no "worth noting".
+- No unrequested code blocks. Show the diff, not the file.
+
+Overrides:
+- "expand" or "why" → caps off, that reply only.
+- "brief me" → 5 bullets max.
+
 ## Critical: Read Before Writing Code
 
 **Read `docs/PIPELINE_V4_DESIGN.md` first.** It defines the pipeline architecture, data flow, and quality gates.


### PR DESCRIPTION
## What & why

Rolls the enterprise **Response Contract** (Variant B) into TPCR's `CLAUDE.md`, per ops #96 (AC-2/3/4). Copied **verbatim** from the canonical master `docs/RESPONSE_CONTRACT.md` on `hazeydata/operations` main (#98, merged).

Refs #96 — does **not** auto-close the issue (spans five repos). Close #96 from the final repo PR.

## Scope ledger

- **AC-2** — `CLAUDE.md` now carries **Variant B** verbatim. Verified byte-identical to the canonical copy on operations main (`diff` clean).
- **AC-3** — Block sits directly under the H1 "AI Agent Guide" title, above `## Critical` and all project content.
- **AC-4** — N/A: the existing `CLAUDE.md` had no verbosity/tone wording (grep clean), so nothing was removed.

**Non-goals preserved:** NG-2 (no operating discipline / DuckDB rules touched), NG-3 (no runner/cron/`AGENTS.md`), NG-7 (Variant B only).

**Other behavior changes: None.** This PR commits **only** `CLAUDE.md`; unrelated uncommitted working-tree edits to pipeline/bot scripts were deliberately left untouched and are not part of this branch.

## Manual test steps

1. `grep -n "response-contract v2" CLAUDE.md` → sentinel present once, at top.
2. `sed -n '1,6p' CLAUDE.md` → Response Contract is the first section after the H1.
3. Extract the block and `diff` against operations `docs/RESPONSE_CONTRACT.md` Variant B → identical.

## Automated checks

Docs-only change — no lint/test suite applies. Verbatim integrity verified by diff.

**Risk: Low** — single documentation file, no code or pipeline paths touched.
